### PR TITLE
design: 로딩 컴포넌트 수정(z-index 사용, 스크롤 문제, 이미지 크기 변경)

### DIFF
--- a/src/components/ui/Loading.module.scss
+++ b/src/components/ui/Loading.module.scss
@@ -3,9 +3,10 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 100vh;
+  min-height: calc(100vh - 60px);
+  z-index: 1002;
   .loadImage {
-    width: 70px;
-    height: 70px;
+    width: 80px;
+    height: 80px;
   }
 }


### PR DESCRIPTION
<변경사항>

1. z-index 설정
- 모달창의 z-index가 1000, 1001임을 고려하여,
  로딩 컴포넌트의 z-index를 1002로 설정하였습니다.

2. 스크롤 문제
- 화면 전체 높이에서  하단 버튼 탭의 높이인
60px만큼 빼서 스크롤이 되는 문제를 해결했습니다.

3. 로딩 이미지 크기 수정