### PR TITLE
design: 글자 수만큼 말풍선 크기 조정

### DIFF
--- a/src/components/chat/ChatForm.module.scss
+++ b/src/components/chat/ChatForm.module.scss
@@ -17,7 +17,6 @@
     display: flex;
     align-items: flex-start;
     max-width: 322px;
-    width: 100%;
   }
   .chatProfile {
     margin-right: 12px;
@@ -26,8 +25,6 @@
   // 사용자 메시지 입력 전 인사 문구
   .message {
     display: flex;
-    max-width: calc(100% - 54px); // 프로파일 이미지 너비(42px)와 마진(12px)을 뺀 값
-    width: 100%;
     padding: 12px;
     border-radius: 10px;
     font-weight: 400;


### PR DESCRIPTION
사용자의 글자 수만큼 말풍선 크기가 조정되도록 수정했습니다.
사용자의 말풍선과 챗봇의 말풍선 크기 둘 다 조절이 되는지 확인하였습니다.
아래 첨부한 사진을 참고해주세요!